### PR TITLE
hotfix: v1.2.1 - fix git fetch error in release automation

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -184,12 +184,12 @@ jobs:
         run: |
           echo "🔄 Syncing develop with main to prevent conflicts..."
 
-          # Fetch latest develop and main
-          git fetch origin develop:develop
-          git fetch origin main:main
+          # Fetch latest from origin - this updates remote tracking branches
+          git fetch origin develop
+          git fetch origin main
 
-          # Check if develop is behind main
-          BEHIND_COUNT=$(git rev-list --count develop..main)
+          # Check if develop is behind main using remote references
+          BEHIND_COUNT=$(git rev-list --count origin/develop..origin/main)
           echo "behind_count=$BEHIND_COUNT" >> $GITHUB_OUTPUT
 
           if [ "$BEHIND_COUNT" -gt 0 ]; then
@@ -237,19 +237,19 @@ jobs:
           BACKMERGE_BRANCH="${{ steps.check_branch.outputs.final_branch }}"
           echo "backmerge_branch=$BACKMERGE_BRANCH" >> $GITHUB_OUTPUT
 
-          # Fetch latest develop and main
-          git fetch origin develop:develop
-          git fetch origin main:main
+          # Fetch latest from origin - this updates remote tracking branches
+          git fetch origin develop
+          git fetch origin main
 
           # Create and checkout new branch from main (not develop) to avoid conflicts
           echo "🌿 Creating branch $BACKMERGE_BRANCH from main"
-          git checkout -b "$BACKMERGE_BRANCH" main
+          git checkout -b "$BACKMERGE_BRANCH" origin/main
 
           # Now merge develop into this branch to see what needs to be preserved
           echo "🔄 Checking for develop-specific changes..."
 
           # Try to merge develop to see if there are any develop-specific changes
-          if git merge develop --no-commit --no-ff 2>/dev/null; then
+          if git merge origin/develop --no-commit --no-ff 2>/dev/null; then
             # Check if there are actual changes from develop
             if git diff --cached --quiet; then
               echo "✅ No develop-specific changes to preserve"
@@ -265,7 +265,7 @@ jobs:
               git merge --abort
 
               # Now create the branch from develop instead
-              git checkout -b "${BACKMERGE_BRANCH}_temp" develop
+              git checkout -b "${BACKMERGE_BRANCH}_temp" origin/develop
               git branch -D "$BACKMERGE_BRANCH"
               git branch -m "${BACKMERGE_BRANCH}_temp" "$BACKMERGE_BRANCH"
             fi
@@ -273,7 +273,7 @@ jobs:
             echo "⚠️ Conflicts detected between main and develop"
             git merge --abort
             # Create from develop in this case
-            git checkout -b "${BACKMERGE_BRANCH}_temp" develop
+            git checkout -b "${BACKMERGE_BRANCH}_temp" origin/develop
             git branch -D "$BACKMERGE_BRANCH" 2>/dev/null || true
             git branch -m "${BACKMERGE_BRANCH}_temp" "$BACKMERGE_BRANCH"
           fi
@@ -288,15 +288,15 @@ jobs:
           fi
 
           # Now perform the actual merge based on the branch base
-          CURRENT_BASE=$(git merge-base HEAD main)
-          MAIN_BASE=$(git merge-base main main)
+          CURRENT_BASE=$(git merge-base HEAD origin/main)
+          MAIN_BASE=$(git merge-base origin/main origin/main)
 
           if [ "$CURRENT_BASE" = "$MAIN_BASE" ]; then
             echo "🔄 Branch is based on main, merging develop changes..."
-            MERGE_TARGET="develop"
+            MERGE_TARGET="origin/develop"
           else
             echo "🔄 Branch is based on develop, merging main changes..."
-            MERGE_TARGET="main"
+            MERGE_TARGET="origin/main"
           fi
 
           # Attempt merge with automatic conflict resolution
@@ -316,8 +316,8 @@ jobs:
               echo "🔄 Resolving version conflict in package.json..."
 
               # Get versions from both branches
-              MAIN_VERSION=$(git show main:package.json | jq -r '.version' 2>/dev/null || echo "0.0.0")
-              DEVELOP_VERSION=$(git show develop:package.json | jq -r '.version' 2>/dev/null || echo "0.0.0")
+              MAIN_VERSION=$(git show origin/main:package.json | jq -r '.version' 2>/dev/null || echo "0.0.0")
+              DEVELOP_VERSION=$(git show origin/develop:package.json | jq -r '.version' 2>/dev/null || echo "0.0.0")
               CURRENT_VERSION=$(jq -r '.version' package.json 2>/dev/null || echo "0.0.0")
 
               echo "  Main version: $MAIN_VERSION"
@@ -327,10 +327,10 @@ jobs:
               # Use the higher version number
               if [ "$(printf '%s\n' "$MAIN_VERSION" "$DEVELOP_VERSION" | sort -V | tail -n1)" = "$DEVELOP_VERSION" ]; then
                 echo "  ✅ Keeping develop version (higher): $DEVELOP_VERSION"
-                git checkout develop -- package.json
+                git checkout origin/develop -- package.json
               else
                 echo "  ✅ Keeping main version (higher): $MAIN_VERSION"
-                git checkout main -- package.json
+                git checkout origin/main -- package.json
               fi
               git add package.json
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v1.2.1] - 2025-09-14
+
+### Fixed
+
+- Resolve git fetch error in release-automation workflow (87b28f1)
+
+
 ## [v1.2.0] - 2025-09-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pico-api-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "PICO SulTeng API Documentation - COVID-19 Sulawesi Tengah Data API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Hotfix v1.2.1 to resolve critical git fetch error in the release automation workflow.

## 🐛 Bug Fix
- Fixed git fetch error in release-automation.yml that was causing workflow failures
- Error: "fatal: refusing to fetch into branch 'refs/heads/main' checked out"

## 🔧 Technical Changes
- Changed `git fetch origin develop:develop` to `git fetch origin develop`
- Changed `git fetch origin main:main` to `git fetch origin main`
- Updated all branch references to use remote tracking branches (`origin/branch`)
- Fixed behind count calculations to use proper remote branch references
- Improved workflow reliability when main branch is checked out

## ✅ Impact
- Release automation workflow will no longer fail with git fetch errors
- Back-merge process will work correctly regardless of checked out branch
- Maintains all existing functionality while improving robustness

## 🧪 Testing
- [x] Git fetch commands tested and validated
- [x] Remote branch references confirmed working
- [x] Behind count calculations verified
- [x] Workflow syntax validated

This is a critical hotfix needed for proper release process functionality.